### PR TITLE
Update service name to Watson IoT Platform

### DIFF
--- a/IoTAppNode.rst
+++ b/IoTAppNode.rst
@@ -1,13 +1,13 @@
 IBM IoT App Node
 ========================
-This is a set of 2 complimentary Nodes - 
+This is a set of two complementary Nodes - 
 
-1. IoT App In Node which is meant for subscribing to IBM IoT Foundation and
-2. IoT App Out Node which is meant for publishing to IBM IoT Foundation 
+1. IoT App In Node which is meant for subscribing to Watson IoT Platform, and
+2. IoT App Out Node which is meant for publishing to Watson IoT Platform 
 
-This set of Nodes is an IoT application which can communicate, bidirectionally, with IBM IoT Foundation. It can be used in both - Quickstart, as well as, in Registered flow. Being an app, it can subscribe to device events, as well as, publish commands for IoT Foundation registered devices. 
+This set of Nodes is an IoT application which can communicate, bidirectionally, with Watson IoT Platform. It can be used in both Quickstart and Registered flows. Being an app, it can subscribe to device events, as well as publish commands for Watson IoT Platform registered devices. 
 
-It can also act as a Proxy for devices. This IoT Pattern is typically used in cases where the device is incapable of sending events or receiving commands. In such a case, the Node can also subscribe to device commands and publish device events. While subscribing to device commands, the device (for which this app is a proxy) should be a registered device.
+It can also act as a Proxy for devices. This IoT pattern is typically used in cases where the device is incapable of sending events or receiving commands. In such a case, the Node can also subscribe to device commands and publish device events. While subscribing to device commands, the device (for which this app is a proxy) should be a registered device.
 
 This set of Nodes provides multiple authentication modes (provided as drop-down), namely 
 
@@ -54,7 +54,7 @@ In case the out and in nodes need to run outside the IBM Bluemix environment, us
 
 Documentation
 -------------
-Adhering to the convention of providing in-line documentation, all the fields, in the Nodes, are well documented and their usage and features can be viewed by just clicking on the node and switching to the Info tab, in the workspace.
+Adhering to the convention of providing in-line documentation, all the fields in the Nodes are well documented and their usage and features can be viewed by just clicking on the node and switching to the Info tab, in the workspace.
 
 Apart from that, the below links provide more detailed information about whats going under the hood for both the nodes.
 

--- a/IoTAppNode.rst
+++ b/IoTAppNode.rst
@@ -22,7 +22,7 @@ This set of Nodes provides multiple authentication modes (provided as drop-down)
 "API Key" option is available even if the Node is running in a non-Bluemix environment or if the application, although running in Bluemix, does not have any bound IoT service. This option makes it possible for an application to communicate with multiple organizations.
 
 
-This set of Nodes depend upon the `iotclient library <https://www.npmjs.com/package/iotclient>`__, made available in npmjs, for performing the IoT Foundation connectivity.
+This set of Nodes depends upon the `iotclient library <https://www.npmjs.com/package/iotclient>`__, made available in npmjs, for performing the Watson IoT Platform connectivity.
 
 
 ----

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Quickstart Flow
 This has a single flow
 Quickstart Flow from device
 ===============================
-This is the sample program to send the following events from the Raspberry Pi to the Quickstart messaging of IBM Internet of Things service.
+This is the sample program to send the following events from the Raspberry Pi to the Quickstart messaging service of IBM Watson IoT Platform.
 
 The events that are emitted in this sample are:
 
@@ -45,7 +45,7 @@ This has 2 flows
 
 Registered Flow from device
 ===============================
-This is the sample program to send the following events from the Raspberry Pi to the Registered messaging of IBM Internet of Things service.
+This is the sample program to send the following events from the Raspberry Pi to the Registered messaging service of IBM Watson IoT Platform.
 
 The events that are emitted in this sample are:
 

--- a/node-red-contrib-scx-ibmiotapp/README.md
+++ b/node-red-contrib-scx-ibmiotapp/README.md
@@ -1,9 +1,9 @@
 ibmiotapp
 ========================
-This is a Node-RED node meant for connecting to both quickstart, as well as, registered flow on the IBM Watson IoT Foundation Connect.
+This is a Node-RED node meant for connecting to both the Quickstart and Registered flows in IBM Watson IoT Platform.
 This Node-RED node replaces the node-red-iotcloudshapeshift. This Node-RED node can be used within, as well as, outside the IBM Bluemix environment. 
   
-In case its used within the IBM Bluemix environment, the node is smart enough to detect whether an IoT service is bound to this application and provides the respective drop-down options. 
+In case it is used within the IBM Bluemix environment, the node is smart enough to detect whether an IoT service is bound to this application and provides the respective drop-down options. 
 In case no IoT service is bound to this application, the drop-down, for authentication, does not contain "Bluemix Service".  
 
 
@@ -19,14 +19,14 @@ Usage
 
 **IoT App In Node**
 
-In case of registered flow, the App In node can be used to 
+In case of Registered flow, the App In node can be used to 
 
 1. Receive device events, 
 2. Receive device status, 
 3. Receive device commands, on the behalf of a device, and 
 4. Receive application status.  
 
-In case of quickstart flow, the App In node can be used to  
+In case of Quickstart flow, the App In node can be used to  
 
 1. Receive device events, 
 2. Receive device status and 

--- a/node-red-contrib-scx-ibmiotapp/application/97-iotnewapp-cf.html
+++ b/node-red-contrib-scx-ibmiotapp/application/97-iotnewapp-cf.html
@@ -165,7 +165,7 @@
 </script>
 
 <script type="text/x-red" data-help-name="ibmiot out">
-   <p>Output node that can be used with the IBM Internet of Things Foundation to send a commands to a device or send an event on the behalf of a device </p>
+   <p>Output node that can be used with Watson IoT Platform to send a commands to a device or send an event on behalf of a device </p>
    <p>The following message properties take precedence and override the values configured in the node:
    <p><b>msg.deviceId </b> overrides the value of "Device Id"</p>
    <p><b>msg.deviceType</b> overrides the value of "Device Type"</p>
@@ -296,7 +296,7 @@
 
 
 <script type="text/x-red" data-help-name="ibmiot in">
-	<p>Input node that can be used with the IBM Internet of Things Foundation to receive events sent from devices, receive commands sent to devices,  or receive status updates concerning devices or applications. It produces an object called msg and sets <b>msg.payload</b> to be a String containing the payload of the incoming message.</p>
+	<p>Input node that can be used with Watson IoT Platform to receive events sent from devices, receive commands sent to devices,  or receive status updates concerning devices or applications. It produces an object called msg and sets <b>msg.payload</b> to be a String containing the payload of the incoming message.</p>
 	<p>The value of "Device Id" is stored in <b>msg.deviceId</b></p>
 	<p>The value of "Application Id" is stored in <b>msg.applicationId</b></p>
 	<p>The value of "Device Type" is stored in  <b>msg.deviceType</b></p>

--- a/node-red-contrib-scx-ibmiotapp/package.json
+++ b/node-red-contrib-scx-ibmiotapp/package.json
@@ -4,7 +4,7 @@
     "email": "amitmangalvedkar@gmail.com"
   },
   "name": "node-red-contrib-scx-ibmiotapp",
-  "description": "IoT Application Node-RED node for the Registered, as well as, Quickstart mode, on the IBM Internet of Things Cloud Foundation",
+  "description": "IoT Application Node-RED node for the Registered and Quickstart flows in IBM Watson IoT Platform",
   "dependencies": {
     "cfenv": "1.0.0",
     "ibmiotf": "^0.2.18",


### PR DESCRIPTION
Replace various occurrences of Internet of Things Foundation with Watson IoT Platform.