### PR TITLE
use 'domain' instead of 'URL'

### DIFF
--- a/node-red-contrib-ibm-watson-iot/application/wiotp.html
+++ b/node-red-contrib-ibm-watson-iot/application/wiotp.html
@@ -478,7 +478,7 @@
         the command is for</li>
        <li><code>deviceId</code> - (<i>gateway only</i>) the id of the device
         the command is for</li>
-       <li><code>domain</code> - (Optional) The messaging endpoint URL. By default 
+       <li><code>domain</code> - (Optional) The messaging endpoint domain. By default 
         the value is "internetofthings.ibmcloud.com"(Watson IoT Production server)</li>
     </ul>
     <p>Value for QoS (Quality of Service) and connection keep alive interval value
@@ -557,7 +557,7 @@
        When clean session is set to <b>false</b>, a persistent session is created and it will be preserved until the client requests a clean session again. 
        If there is already a session available then it is used and queued messages will be delivered to the client if available. For more information, refer to Watson IoT Platform documentation.
     </p>
-    <p>In Registered Mode, the <code>domain</code> property can be optionally used to specify the Watson IoT Platform messaging endpoint URL. By default the value is "internetofthings.ibmcloud.com"(Watson IoT Production server).
+    <p>In Registered Mode, the <code>domain</code> property can be optionally used to specify the Watson IoT Platform messaging endpoint domain. By default the value is "internetofthings.ibmcloud.com"(Watson IoT Production server).
     </p>
 
 </script>


### PR DESCRIPTION
to describe what the 'domain' property is.